### PR TITLE
Fix issue where recursive POSIX1E ops failed to chown (#28)

### DIFF
--- a/nfs4xdr_winacl/nfs4xdr_winacl.c
+++ b/nfs4xdr_winacl/nfs4xdr_winacl.c
@@ -450,6 +450,13 @@ set_acl_posix(struct windows_acl_info *w, FTSENT *file)
 	}
 
 	if (file->fts_level == FTS_ROOTLEVEL) {
+		if (w->uid != -1 || w->gid != -1) {
+			error = chown(file->fts_accpath, w->uid, w->gid);
+			if (error) {
+				warn("%s: chown() failed", file->fts_accpath);
+				return (-1);
+			}
+		}
 		return (0);
 	}
 


### PR DESCRIPTION
We bail out of setacl operation early if this is the root level, but we may still need to chown.